### PR TITLE
ci : Move arm64 platform image build to a separate github workflow

### DIFF
--- a/.github/workflows/build-oci.yaml
+++ b/.github/workflows/build-oci.yaml
@@ -9,15 +9,10 @@ on:
     branches: [ main ]
 
 jobs:
-  build:
-    name: build
+  build-amd64:
+    name: build-amd64
     runs-on: ubuntu-24.04
     steps:
-      - name: Prepare runner for build multi arch
-        shell: bash
-        run: |
-          sudo apt-get update && sudo apt-get install -y qemu-user-static
-
       - name: Checkout code
         uses: actions/checkout@v4
 
@@ -27,35 +22,71 @@ jobs:
           IMG: ghcr.io/redhat-developer/mapt:pr-${{ github.event.number }}
         shell: bash
         run: |
-          make oci-build
-          make oci-save
+          make oci-build-amd64
+          make oci-save-amd64
           echo ${IMG} > mapt-image
 
       - name: Build and Push image for Release
         if: github.event_name == 'push'
         run: |
-          make oci-build
-          make oci-save
+          make oci-build-amd64
+          make oci-save-amd64
 
       - name: Upload mapt artifacts for PR
         uses: actions/upload-artifact@v4
         with:
-          name: mapt
-          path: mapt*
+          name: mapt-amd64
+          path: mapt-amd64*
+  
+  build-arm64:
+    name: build-arm64
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Install Podman
+        run: |
+          sudo apt-get update -y
+          sudo apt-get -y install podman  
+      - name: Build image for PR
+        if: github.event_name == 'pull_request'
+        env:
+          IMG: ghcr.io/redhat-developer/mapt:pr-${{ github.event.number }}
+        shell: bash
+        run: |
+          uname -a
+          make oci-build-arm64
+          make oci-save-arm64
+          echo ${IMG} > mapt-image
+
+      - name: Build and Push image for Release
+        if: github.event_name == 'push'
+        run: |
+          make oci-build-arm64
+          make oci-save-arm64
+
+      - name: Upload mapt artifacts for PR
+        uses: actions/upload-artifact@v4
+        with:
+          name: mapt-arm64
+          path: mapt-arm64*
 
   push:
     name: push
-    if: github.event_name == 'push' 
-    needs: build
+    needs: ["build-amd64", "build-arm64"]
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Download mapt oci flatten images
+      - name: Download mapt amd64 oci flatten images
         uses: actions/download-artifact@v4
         with:
-          name: mapt
+          name: mapt-amd64
+      - name: Download mapt arm64 oci flatten images
+        uses: actions/download-artifact@v4
+        with:
+          name: mapt-arm64          
         
       - name: Log in quay.io
         uses: redhat-actions/podman-login@v1

--- a/.github/workflows/push-oci-pr.yml
+++ b/.github/workflows/push-oci-pr.yml
@@ -21,7 +21,13 @@ jobs:
       - name: Download mapt assets
         uses: actions/download-artifact@v4
         with:
-          name: mapt
+          name: mapt-amd64
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+      - name: Download mapt assets
+        uses: actions/download-artifact@v4
+        with:
+          name: mapt-arm64
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ github.token }}
       

--- a/Makefile
+++ b/Makefile
@@ -89,22 +89,44 @@ lint: $(TOOLS_BINDIR)/golangci-lint
 
 # Build the container image
 .PHONY: oci-build
-oci-build: clean
-	# ${CONTAINER_MANAGER} build -t $(IMG) -f oci/Containerfile .
+oci-build: clean oci-build-amd64 oci-build-arm64
+
+# Build for amd64 architecture only
+.PHONY: oci-build-amd64
+oci-build-amd64: clean
+	# Build the container image for amd64
 	${CONTAINER_MANAGER} build --platform linux/amd64 --manifest $(IMG)-amd64 -f oci/Containerfile .
+
+# Build for arm64 architecture only
+.PHONY: oci-build-arm64
+oci-build-arm64: clean
+	# Build the container image for arm64
 	${CONTAINER_MANAGER} build --platform linux/arm64 --manifest $(IMG)-arm64 -f oci/Containerfile .
+
+# Save images for both amd64 and arm64 architectures
+.PHONY: oci-save
+oci-save: oci-save-amd64 oci-save-arm64
+
+# Save images for amd64 architecture only
+.PHONY: oci-save-amd64
+oci-save-amd64:
+	${CONTAINER_MANAGER} save -m -o $(MAPT_SAVE)-amd64.tar $(IMG)-amd64
+
+# Save images for arm64 architecture only
+.PHONY: oci-save-arm64
+oci-save-arm64:
+	${CONTAINER_MANAGER} save -m -o $(MAPT_SAVE)-arm64.tar $(IMG)-arm64
+
 
 MAPT_SAVE ?= mapt
 .PHONY: oci-save 
-oci-save: ARM64D=$(shell ${CONTAINER_MANAGER} manifest inspect ${IMG}-arm64 | jq '.manifests[0].digest')
-oci-save: 
-	${CONTAINER_MANAGER} manifest annotate --arch amd64 $(IMG)-arm64 $(ARM64D)
-	${CONTAINER_MANAGER} save -m -o $(MAPT_SAVE)-amd64.tar $(IMG)-amd64
-	${CONTAINER_MANAGER} save -m -o $(MAPT_SAVE)-arm64.tar $(IMG)-arm64
+oci-save: oci-save-amd64 oci-save-arm64
 
 oci-load:
 	${CONTAINER_MANAGER} load -i $(MAPT_SAVE)-arm64.tar 
 	${CONTAINER_MANAGER} load -i $(MAPT_SAVE)-amd64.tar 
+	ARM64D=$(shell ${CONTAINER_MANAGER} manifest inspect ${IMG}-arm64 | jq '.manifests[0].digest')
+	${CONTAINER_MANAGER} manifest annotate --arch amd64 $(IMG)-arm64 $(ARM64D)
 
 # Push the docker image
 .PHONY: oci-push


### PR DESCRIPTION
Split oci-build Makefile target into different targets for handling
amd64 and arm64 platforms separately.

Use a separate github action workflow to invoke separated Makefile targets
to create container images

Signed-off-by: Rohan Kumar <rohaan@redhat.com>